### PR TITLE
Feat import photos

### DIFF
--- a/src/pages/InstaImport/index.js
+++ b/src/pages/InstaImport/index.js
@@ -1,10 +1,16 @@
 import React, { useState } from "react";
 import { Jumbotron } from "react-bootstrap";
 import Axios from "axios";
+import { useDispatch, useSelector } from "react-redux";
+import { selectUser } from "../../store/user/selectors";
+import { importPhoto } from "../../store/photo/actions";
 
 export default function InstaImport() {
   const [handle, set_handle] = useState("");
   const [feed, set_feed] = useState([]);
+
+  const dispatch = useDispatch();
+  const user = useSelector(selectUser);
 
   async function instagramPhotos(get_handle) {
     // It will contain our photos' links
@@ -22,7 +28,7 @@ export default function InstaImport() {
         .slice(0, -1);
 
       const userInfo = JSON.parse(jsonObject);
-      // Retrieve only the first 10 results
+      // Retrieve only the first 12 results
       const mediaArray = userInfo.entry_data.ProfilePage[0].graphql.user.edge_owner_to_timeline_media.edges.splice(
         0,
         12
@@ -59,7 +65,12 @@ export default function InstaImport() {
   function cancelImport() {
     set_feed([]);
   }
-  console.log(feed);
+  function importPhotos() {
+    feed.map((photo) => {
+      dispatch(importPhoto(photo.description, photo.info, photo.src, user.id));
+    });
+  }
+  //   console.log(feed);
 
   const inputFieldsToRender = () => {
     return (
@@ -85,10 +96,17 @@ export default function InstaImport() {
     return (
       <div>
         {feed.map((photo, index) => {
-          return <img src={photo.src} alt={photo.info} key={index} />;
+          return (
+            <img
+              src={photo.src}
+              alt={photo.info}
+              key={index}
+              style={{ width: "32%", margin: "5px" }}
+            />
+          );
         })}
         <div>
-          <button>Import</button>
+          <button onClick={importPhotos}>Import</button>
           <button onClick={cancelImport}>Cancel</button>
         </div>
       </div>

--- a/src/pages/InstaImport/index.js
+++ b/src/pages/InstaImport/index.js
@@ -36,8 +36,12 @@ export default function InstaImport() {
           continue;
         }
 
-        // Push the thumbnail src in the array
-        res.push(node.thumbnail_src);
+        // Push the photo data in the array
+        res.push({
+          description: node.edge_media_to_caption.edges[0].node.text,
+          info: node.accessibility_caption,
+          src: node.thumbnail_src,
+        });
       }
     } catch (e) {
       console.error("Unable to retrieve photos. Reason: " + e.toString());
@@ -51,29 +55,52 @@ export default function InstaImport() {
     console.log("handle looking for:", handle);
     set_feed(await instagramPhotos(handle));
   }
-  //console.log(feed);
+
+  function cancelImport() {
+    set_feed([]);
+  }
+  console.log(feed);
+
+  const inputFieldsToRender = () => {
+    return (
+      <div>
+        <form>
+          <label htmlFor="instaHandle">Instagram name:</label>
+          <br />
+          <input
+            type="text"
+            id="instaHandle"
+            name="instaHandle"
+            value={handle}
+            onChange={(e) => set_handle(e.target.value)}
+          />
+          <br />
+          <button onClick={submit}>Find</button>
+        </form>
+      </div>
+    );
+  };
+
+  const importPreview = () => {
+    return (
+      <div>
+        {feed.map((photo, index) => {
+          return <img src={photo.src} alt={photo.info} key={index} />;
+        })}
+        <div>
+          <button>Import</button>
+          <button onClick={cancelImport}>Cancel</button>
+        </div>
+      </div>
+    );
+  };
 
   return (
     <div>
       <Jumbotron>
         <h1>Import pictures from Instagram</h1>
       </Jumbotron>
-      <form>
-        <label htmlFor="instaHandle">Instagram name:</label>
-        <br />
-        <input
-          type="text"
-          id="instaHandle"
-          name="instaHandle"
-          value={handle}
-          onChange={(e) => set_handle(e.target.value)}
-        />
-        <br />
-        <button onClick={submit}>submit</button>
-      </form>
-      {feed.map((photo, index) => {
-        return <img src={photo} alt={index} key={index} />;
-      })}
+      {feed.length ? importPreview() : inputFieldsToRender()}
     </div>
   );
 }

--- a/src/store/photo/actions.js
+++ b/src/store/photo/actions.js
@@ -15,3 +15,21 @@ export const getSinglePhoto = (id) => async (dispatch, getState) => {
     console.log(e);
   }
 };
+
+export const importPhoto = (description, info, src, userId) => async (
+  dispatch,
+  getState
+) => {
+  //   console.log("importing", description, info, src, "from", userId);
+  try {
+    const response = await Axios.post(`${apiUrl}/photos/new`, {
+      description,
+      info,
+      src,
+      userId,
+    });
+    console.log(response);
+  } catch (e) {
+    console.log(e);
+  }
+};


### PR DESCRIPTION
## What this pull request does:
- Import photo page now shows form to scrape photo's from an instagram account
  - input field requires instagram handle
  - when 'find' button is pressed it returns most recent 12 photos posted on said account
  - photos are displayed with 'import' and 'cancel' button
    - import stores all photos in database
    - cancel removes scraped photos from local state and returns to the form

### Future must have
- Authentication for instagram handle

### Future nice to have
- Ability to select how many photos are scraped (up to 12 with current function)
- Additional options in preview
  - remove photos from preview 
  - ability to edit description or info

  
